### PR TITLE
chore: Update saveDocumentWithPageIndex method to accept an array of page indexes

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -314,8 +314,8 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
             case COMMAND_SAVE_DOCUMENT_WITH_PAGE_INDICES:
                 if (args != null) {
                     final int requestId = args.getInt(0);
-                    final int pageIndex = args.getInt(1); // Get the page index
-                    final String outputPath = args.getString(2); // Get the output path
+                    final ArrayList<Object> pageIndex  = args.getArray(1).toArrayList(); // Get the page index
+                    final String outputPath = args.getString(2); // Get the output pat
                     Log.d("ReactPdfViewManager", "Page Index: " + pageIndex + ", Output Path: " + outputPath);
                     try {
                     boolean result = root.saveDocumentWithPageIndices(pageIndex, outputPath); // Pass both parameters to the method
@@ -328,7 +328,19 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
             case COMMAND_SAVE_IMAGE_FROM_PDF:
                 if (args != null) {
                     final int requestId = args.getInt(0);
-                    final int pageIndex = args.getInt(1); // Get the page index
+                    final ArrayList<Object> pageIndexObjects = args.getArray(1).toArrayList(); // Get the page index
+                    int pageIndex = 0; // Default value in case the array is empty
+                    if (!pageIndexObjects.isEmpty()) {
+                        Object firstElement = pageIndexObjects.get(0);
+                        if (firstElement instanceof Double) {
+                            pageIndex = ((Double) firstElement).intValue();
+                        } else if (firstElement instanceof Integer) {
+                            pageIndex = (Integer) firstElement;
+                        } else {
+                            // Handle non-integer values as needed
+                            throw new IllegalArgumentException("Non-integer value found in array");
+                        }
+                    }
                     final String outputPath = args.getString(2); // Get the output path
                     Log.d("ReactPdfViewManager", "Page Index: " + pageIndex + ", Output Path: " + outputPath);
                     try {

--- a/android/src/main/java/com/pspdfkit/views/PdfView.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfView.java
@@ -747,7 +747,7 @@ public class PdfView extends FrameLayout {
         return false;
     }
 
-    public boolean saveDocumentWithPageIndices(int pageIndex, String outputPath) throws Exception {
+    public boolean saveDocumentWithPageIndices(ArrayList<Object> pageIndex, String outputPath) throws Exception {
         // Check if outputPath is an absolute path
         File outputFile;
         if (new File(outputPath).isAbsolute()) {
@@ -762,7 +762,19 @@ public class PdfView extends FrameLayout {
 
         if (fragment != null && document != null) {
             try {
-                HashSet<Integer> pageIndices = new HashSet<>(Arrays.asList(pageIndex));
+                HashSet<Integer> pageIndices = new HashSet<>();
+                for (Object item : pageIndex) {
+                     if (item instanceof Double) {
+                        // Convert Double to Integer
+                        pageIndices.add(((Double) item).intValue());
+                    } else if (item instanceof Integer) {
+                        // Directly add Integer
+                        pageIndices.add((Integer) item);
+                    } else {
+                        // Handle non-integer values as needed
+                        throw new IllegalArgumentException("Non-integer value found in array");
+                    }
+                }
                 PdfProcessorTask task = PdfProcessorTask.fromDocument(document).keepPages(pageIndices);
                 PdfProcessor.processDocument(task, outputFile);
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -45,8 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Document
 - (BOOL)saveCurrentDocumentWithError:(NSError *_Nullable *)error;
-- (BOOL)saveDocumentWithPageIndex:(NSUInteger)pageIndex outputPath:(NSString *)outputPath error:(NSError **)error;
-- (BOOL)saveImageFromPDF:(NSUInteger)pageIndex outputPath:(NSString *)outputPath error:(NSError **)error;
+- (BOOL)saveDocumentWithPageIndex:(NSArray<NSNumber *> *)pageIndexes outputPath:(NSString *)outputPath error:(NSError **)error;
+- (BOOL)saveImageFromPDF:(NSArray<NSNumber *> *)pageIndexes outputPath:(NSString *)outputPath error:(NSError **)error;
 
 /// Anotations
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAnnotations:(PSPDFPageIndex)pageIndex type:(PSPDFAnnotationType)type error:(NSError *_Nullable *)error;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -147,10 +147,16 @@
   return [self.pdfController.document saveWithOptions:nil error:error];
 }
 
-- (BOOL)saveDocumentWithPageIndex:(NSUInteger)pageIndex outputPath:(NSString *)filename error:(NSError **)error {
+- (BOOL)saveDocumentWithPageIndex:(NSArray<NSNumber *> *)pageIndexes outputPath:(NSString *)filename error:(NSError **)error {
     PSPDFDocument *document = self.pdfController.document;
     PSPDFProcessorConfiguration *configuration = [[PSPDFProcessorConfiguration alloc] initWithDocument:document];
-    [configuration includeOnlyIndexes:[NSIndexSet indexSetWithIndex:pageIndex]];
+
+    NSMutableIndexSet *indexSet = [[NSMutableIndexSet alloc] init];
+    for (NSNumber *pageIndex in pageIndexes){
+      [indexSet addIndex:[pageIndex unsignedIntegerValue]];
+    }
+
+    [configuration includeOnlyIndexes:indexSet];
 
     NSString *fullPath;
     // Determine if filename is an absolute path
@@ -179,7 +185,7 @@
 }
 
 
-- (BOOL)saveImageFromPDF:(NSUInteger)pageIndex outputPath:(NSString *)filename error:(NSError **)error {
+- (BOOL)saveImageFromPDF:(NSArray<NSNumber *> *)pageIndexes outputPath:(NSString *)filename error:(NSError **)error {
   PSPDFDocument *document = self.pdfController.document;
 
   // Determine if filename is an absolute path
@@ -195,6 +201,9 @@
 
   // Print the full output path to the console
   NSLog(@"Full output path: %@", fullPath);
+
+  //Extract the single page index
+  NSUInteger pageIndex = [pageIndexes[0] unsignedIntegerValue];
 
   // Get the size of the PDF page
   PSPDFPageInfo *pageInfo = [document pageInfoForPageAtIndex:pageIndex];

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -301,7 +301,7 @@ RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag resolver:(RCT
 }
 
 RCT_EXPORT_METHOD(saveDocumentWithPageIndex:(nonnull NSNumber *)reactTag 
-                                  pageIndex:(NSUInteger)pageIndex 
+                                  pageIndex:(NSArray<NSNumber *> *)pageIndex 
                                  outputPath:(NSString *)outputPath
                                documentType:(NSString *)documentType
                                    resolver:(RCTPromiseResolveBlock)resolve 


### PR DESCRIPTION
Update saveDocumentWithPageIndex method to accept an array of page indexes

The saveDocumentWithPageIndex method in RCTPSPDFKitViewManager.m has been updated to accept an array of page indexes instead of a single index. This change allows for saving multiple pages of a PDF document at once.
