### PR TITLE
feat: Remove document android

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/PDFDocumentModule.kt
+++ b/android/src/main/java/com/pspdfkit/react/PDFDocumentModule.kt
@@ -26,12 +26,13 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.util.EnumSet
+import java.util.concurrent.ConcurrentHashMap
 
 @ReactModule(name = PDFDocumentModule.NAME)
 class PDFDocumentModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
-    private var documents = mutableMapOf<Int, PdfDocument>()
-    private var documentConfigurations = mutableMapOf<Int, MutableMap<String, Any>>()
+    private var documents = ConcurrentHashMap<Int, PdfDocument>()
+    private var documentConfigurations = ConcurrentHashMap<Int, MutableMap<String, Any>>()
 
     override fun getName(): String {
         return NAME
@@ -77,6 +78,20 @@ class PDFDocumentModule(reactContext: ReactApplicationContext) : ReactContextBas
             promise.resolve(true)
         } catch (e: Throwable) {
             promise.reject("invalidateCache error", e)
+        }
+    }
+
+    @ReactMethod fun removeDocument(reference: Int, promise: Promise) {
+        try {
+            if (documents.containsKey(reference)) {
+                documents.remove(reference)
+                documentConfigurations.remove(reference)
+                promise.resolve(true)
+            } else {
+                promise.reject("INVALID_DOCUMENT", "No document found for reference: $reference")
+            }
+        } catch (e: Throwable) {
+            promise.reject("removeDocument error", e)
         }
     }
 


### PR DESCRIPTION
- Implemented removeDocument method in PDFDocumentModule
- Replaced mutable maps with ConcurrentHashMap for thread-safe document and configuration storage
- Added error handling for document removal scenarios
- Provides a way to explicitly remove a document reference from memory

# Details

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, `samples/Catalog/yarn.lock`, `samples/NativeCatalog/package.json`, and `samples/NativeCatalog/yarn.lock` (see example commit: https://github.com/PSPDFKit/react-native/pull/403/commits/b32b4edd97ee9b49c51c8b932e2bf477744c2b24).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
